### PR TITLE
default to include metrics on

### DIFF
--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -108,6 +108,9 @@ service:
 
 # Metrics service resource
 metrics:
+  controllerManagerAddr: ":8080"
+  listenerAddr: ":8080"
+  listenerEndpoint: "/metrics"
   serviceAnnotations: {}
   serviceMonitor:
     enable: false
@@ -233,7 +236,10 @@ githubWebhookServer:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
-  podAnnotations: {}
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "8080"
   podLabels: {}
   podSecurityContext: {}
   # fsGroup: 2000

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -89,10 +89,10 @@ priorityClassName: ""
 ## This will disable metrics.
 ##
 ## To enable metrics, uncomment the following lines.
-# metrics:
-#   controllerManagerAddr: ":8080"
-#   listenerAddr: ":8080"
-#   listenerEndpoint: "/metrics"
+metrics:
+  controllerManagerAddr: ":8080"
+  listenerAddr: ":8080"
+  listenerEndpoint: "/metrics"
 
 flags:
   ## Log level can be set here with one of the following values: "debug", "info", "warn", "error".

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -119,6 +119,17 @@ githubConfigSecret:
 #     # Spec for this container will be applied as is without any modifications.
 #     - name: side-car
 #       image: example-sidecar
+listenerTemplate:
+  spec:
+    containers:
+      - name: listener
+        securityContext:
+          runAsUser: 1000
+  metadata:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+      prometheus.io/path: "/metrics"
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec


### PR DESCRIPTION
defaults to turning on metrics

verified in vcluster using:
```
# from root
cd charts
NAMESPACE="arc-systems"                                                             
helm install arc \
    --namespace "${NAMESPACE}" \
    --create-namespace \
gha-runner-scale-set-controller
# then
helm install "${INSTALLATION_NAME}" \
    --namespace "${NAMESPACE}" \
    --create-namespace \
    --set githubConfigUrl="${GITHUB_CONFIG_URL}" \
    --set githubConfigSecret.github_token="${GITHUB_PAT}" gha-runner-scale-set
# then
kubectl port-forward arc-gha-rs-controller-58867c8bc5-zd6ls -n arc-systems 8080:8080
curl localhost:8080/metrics
```